### PR TITLE
Absolute documentation URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Part of the implementation has been adapted, improved and fixed from [Molten](ht
 
 ## Usage
 
-See the [documentation](docs/quickstart.rst) for more information.
+See the [documentation](https://github.com/sdispater/tomlkit/blob/master/docs/quickstart.rst) for more information.
 
 ## Installation
 


### PR DESCRIPTION
The link does not work in [PyPI page](https://pypi.org/project/tomlkit/).